### PR TITLE
docs: Fix and refine protocol setup docs

### DIFF
--- a/docs/03-build/01-protocol-sdks/02-protocol-rs-sdk.mdx
+++ b/docs/03-build/01-protocol-sdks/02-protocol-rs-sdk.mdx
@@ -215,6 +215,7 @@ use calimero_sdk::{app, env};
 
 #[app::state]
 #[derive(Default, BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "calimero_sdk::borsh")]
 struct KvStore {
     entries: HashMap<String, String>,
 }

--- a/docs/03-build/01-protocol-sdks/02-protocol-rs-sdk.mdx
+++ b/docs/03-build/01-protocol-sdks/02-protocol-rs-sdk.mdx
@@ -54,7 +54,7 @@ You can now configure your project to use the Calimero SDK by adding it as a dep
 
 ```toml title="File: Cargo.toml"
 [dependencies]
-calimero-sdk = { git = "https://github.com/calimero-network/core" }
+calimero-sdk = { git = "https://github.com/calimero-network/core/crates/sdk" }
 ```
 
 Then, we need to specify a custom build profile for the most compact Wasm output:
@@ -64,8 +64,9 @@ Then, we need to specify a custom build profile for the most compact Wasm output
 inherits = "release"
 codegen-units = 1
 opt-level = "z"
-lto = true
+lto = "thin"
 debug = false
+strip = true
 panic = "abort"
 overflow-checks = true
 ```
@@ -86,7 +87,7 @@ crate-type = ["cdylib"]
 
 # highlight-start
 [dependencies]
-calimero-sdk = { git = "https://github.com/calimero-network/core" }
+calimero-sdk = { git = "https://github.com/calimero-network/core/crates/sdk" }
 # highlight-end
 
 # highlight-start
@@ -94,8 +95,9 @@ calimero-sdk = { git = "https://github.com/calimero-network/core" }
 inherits = "release"
 codegen-units = 1
 opt-level = "z"
-lto = true
+lto = "thin"
 debug = false
+strip = true
 panic = "abort"
 overflow-checks = true
 # highlight-end

--- a/docs/03-build/01-protocol-sdks/02-protocol-rs-sdk.mdx
+++ b/docs/03-build/01-protocol-sdks/02-protocol-rs-sdk.mdx
@@ -111,24 +111,47 @@ set -e
 
 cd "$(dirname $0)"
 
-TARGET="${CARGO_TARGET_DIR:-../../target}"
+# Check if rustup is installed
+if ! command -v rustup &> /dev/null; then
+  echo "Error: rustup is not installed"
+  echo "Please install rustup in order to use this build script."
+  exit 1
+fi
 
-rustup target add wasm32-unknown-unknown
+# Check if the wasm32-unknown-unknown target is installed
+if ! rustup target list --installed | grep -q "wasm32-unknown-unknown"; then
+  echo "Error: Target wasm32-unknown-unknown is not installed"
+  echo "Please run 'rustup target add wasm32-unknown-unknown' to install it."
+  exit 1
+fi
 
+# Get the application name from Cargo
+APP_ID=$(cargo pkgid)
+APP_NAME=${APP_ID#*#}
+APP_NAME=${APP_NAME%%:*}
+TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+WASM_FILE="$TARGET_DIR/wasm32-unknown-unknown/app-release/$APP_NAME.wasm"
+
+# Build the application
 cargo build --target wasm32-unknown-unknown --profile app-release
+
+# Check if the WASM file exists
+if [[ ! -f "$WASM_FILE" ]]; then
+  echo "Error: WASM file $WASM_FILE not found"
+  exit 1
+fi
 
 mkdir -p res
 
-cp $TARGET/wasm32-unknown-unknown/app-release/kv_store.wasm ./res/
-```
+cp "$WASM_FILE" ./res/
 
-You can optionally choose to install and use [`wasm-opt`](https://github.com/WebAssembly/binaryen), for an additional optimization step in the build script. This step is not required but can help reduce the size of the generated Wasm file:
-
-```bash title="File: build.sh"
+# Optimize the WASM file
 if command -v wasm-opt > /dev/null; then
   wasm-opt -Oz ./res/kv_store.wasm -o ./res/kv_store.wasm
 fi
 ```
+
+You can optionally choose to install and use [`wasm-opt`](https://github.com/WebAssembly/binaryen), for an additional optimization step in the build script (the final stage above). This step is not required, but can help reduce the size of the generated Wasm file.
 
 Don't forget to make the `build.sh` script executable:
 


### PR DESCRIPTION
**Refined the example build script**

  - Corrected Cargo target directory.
  - Added checks and error-handling to the example build script.
  - Removed command to install Wasm target in favour of checking via `rustup` instead.
  - Removed hard-coded application name and obtained this via `cargo` instead.

**Adjusted example `Cargo.toml`**

  - Corrected path to SDK crate.
  - Adjusted `app-release` profile to strip symbols from the binary, and optimise LTO for speed.

**Fixed complete code example**

  - Added missing `borsh` configuration line.