### PR TITLE
docs: update event docs

### DIFF
--- a/docs/04-build/02-client-sdks/02-client-ts-sdk.mdx
+++ b/docs/04-build/02-client-sdks/02-client-ts-sdk.mdx
@@ -91,34 +91,38 @@ export interface RpcMutateResponse<Output> {
 
 ```typescript
 export interface SubscriptionsClient {
-  connect(connectionId?: string): void;
+  connect(connectionId?: string): Promise<void>;
   disconnect(connectionId?: string): void;
-  subscribe(applicationIds: string[], connectionId?: string): void;
-  unsubscribe(applicationIds: string[], connectionId?: string): void;
-  addCallback(
-    callback: (event: NodeEvent) => void,
-    connectionId?: string,
-  ): void;
+  subscribe(contextIds: string[], connectionId?: string): void;
+  unsubscribe(contextIds: string[], connectionId?: string): void;
+  addCallback(callback: (event: NodeEvent) => void, connectionId?: string): void;
   removeCallback(
     callback: (event: NodeEvent) => void,
     connectionId?: string,
   ): void;
 }
 
-export type NodeEvent = ApplicationEvent;
+export type NodeEvent = ContextEvent;
 
-export interface ApplicationEvent {
-  application_id: ApplicationId;
-  type: 'TransactionExecuted' | 'PeerJoined';
-  data: TransactionExecuted | PeerJoined;
+export type ContextEvent = ContextEventPayload & {
+  contextId: ContextId;
 }
 
-export interface TransactionExecuted {
-  hash: string;
+type ContextEventPayload = {
+  type: 'StateMutation',
+  data: StateMutation,
+} | {
+  type: 'ExecutionEvent',
+  data: ExecutionEvent,
+};
+
+export interface StateMutation {
+  newRoot: string;
 }
 
-export interface PeerJoined {
-  peerId: string;
+export interface ExecutionEvent {
+  kind: string,
+  data: any,
 }
 ```
 


### PR DESCRIPTION
Looks like the client SDK docs haven't been updated in a minute, anyway I just made changes to the events API on the node, so these need to change as well.

feature patch: https://github.com/calimero-network/core/pull/864