### PR TITLE
fix: use merod for node start

### DIFF
--- a/docs/06-tutorials/07-awesome-projects/03-building-with-icp.mdx
+++ b/docs/06-tutorials/07-awesome-projects/03-building-with-icp.mdx
@@ -173,15 +173,15 @@ More on node initialization can be found [here](/getting-started/setup/).
 Now we are going to start the nodes with the commands:
 
 ```bash title="Node1 Terminal"
-cargo run -p merod -- --node-name node1 run
+merod --node-name node1 run
 ```
 
 ```bash title="Node2 Terminal"
-cargo run -p merod -- --node-name node2 run
+merod --node-name node2 run
 ```
 
 ```bash title="Node3 Terminal"
-cargo run -p merod -- --node-name node3 run
+merod --node-name node3 run
 ```
 
 After running the nodes you should see the similar to this one:


### PR DESCRIPTION
Changed ICP tutorial step for node start command to use merod