### PR TITLE
Fix: fixed application flag and steps, added protocol flag

### DIFF
--- a/docs/06-tutorials/06-install-application.mdx
+++ b/docs/06-tutorials/06-install-application.mdx
@@ -18,8 +18,7 @@ If the node doesn't have application installed, you need to install the applicat
 If the application is already installed, you can skip this step.
 
 ```bash
-$ meroctl app install --path /path/to/app
->> <app-id>
+meroctl app install --path /path/to/app
 ```
 
 After the application is installed, you can create new context:
@@ -34,22 +33,19 @@ After the application is installed, you can create new context:
 
 <TabItem value="near">
 ```bash title="Terminal"
-$ meroctl context create --application-id <app-id> --protocol near
->> <context-id>
+meroctl context create --application-id <app-id> --protocol near
 ```
 </TabItem>
 
 <TabItem value="starknet">
 ```bash title="Terminal"
-$ meroctl context create --application-id <app-id> --protocol starknet
->> <context-id>
+meroctl context create --application-id <app-id> --protocol starknet
 ```
 </TabItem>
 
 <TabItem value="icp">
 ```bash title="Terminal"
-$ meroctl context create --application-id <app-id> --protocol icp
->> <context-id>
+meroctl context create --application-id <app-id> --protocol icp
 ```
 </TabItem>
 

--- a/docs/06-tutorials/06-install-application.mdx
+++ b/docs/06-tutorials/06-install-application.mdx
@@ -14,8 +14,9 @@ you need to create new context where application will be installed.
 
 To create new context, node CLI has to be used.
 
-If the node doesn't have application installed, you need to install the application first.
-If the application is already installed, you can skip this step.
+If the node doesn't have application installed, you need to install the
+application first. If the application is already installed, you can skip this
+step.
 
 ```bash
 meroctl app install --path /path/to/app

--- a/docs/06-tutorials/06-install-application.mdx
+++ b/docs/06-tutorials/06-install-application.mdx
@@ -3,32 +3,57 @@ id: install-application
 title: Install application
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 We have created simple and easy to use example application called `only-peers`.
 Application enables writing posts and leaving comments. To try out application
 you need to create new context where application will be installed.
 
 ### Create new context
 
-To create new context, node CLI has to be used. There are two possible options
-of creating new context.
+To create new context, node CLI has to be used.
 
-1. If the node already has application installed, create new context using
-   command:
+If the node doesn't have application installed, you need to install the application first.
+If the application is already installed, you can skip this step.
 
-```bash title="Terminal"
-$ meroctl context create --application <app-id>
->> <context-id>
-```
-
-2. If application is not installed then install the application and create new
-   context using commands:
-
-```bash title="Terminal"
+```bash
 $ meroctl app install --path /path/to/app
 >> <app-id>
-$ meroctl context create --application <app-id>
+```
+
+After the application is installed, you can create new context:
+
+<Tabs
+    defaultValue="near"
+    values={[
+        {label: 'Near', value: 'near'},
+        {label: 'Starknet', value: 'starknet'},
+        {label: 'ICP', value: 'icp'},
+    ]}>
+
+<TabItem value="near">
+```bash title="Terminal"
+$ meroctl context create --application-id <app-id> --protocol near
 >> <context-id>
 ```
+</TabItem>
+
+<TabItem value="starknet">
+```bash title="Terminal"
+$ meroctl context create --application-id <app-id> --protocol starknet
+>> <context-id>
+```
+</TabItem>
+
+<TabItem value="icp">
+```bash title="Terminal"
+$ meroctl context create --application-id <app-id> --protocol icp
+>> <context-id>
+```
+</TabItem>
+
+</Tabs>
 
 You are now part of the context and can start using the application.
 

--- a/versioned_docs/version-0.3.0/06-tutorials/06-install-application.mdx
+++ b/versioned_docs/version-0.3.0/06-tutorials/06-install-application.mdx
@@ -18,8 +18,7 @@ If the node doesn't have application installed, you need to install the applicat
 If the application is already installed, you can skip this step.
 
 ```bash
-$ meroctl app install --path /path/to/app
->> <app-id>
+meroctl app install --path /path/to/app
 ```
 
 After the application is installed, you can create new context:
@@ -34,22 +33,19 @@ After the application is installed, you can create new context:
 
 <TabItem value="near">
 ```bash title="Terminal"
-$ meroctl context create --application-id <app-id> --protocol near
->> <context-id>
+meroctl context create --application-id <app-id> --protocol near
 ```
 </TabItem>
 
 <TabItem value="starknet">
 ```bash title="Terminal"
-$ meroctl context create --application-id <app-id> --protocol starknet
->> <context-id>
+meroctl context create --application-id <app-id> --protocol starknet
 ```
 </TabItem>
 
 <TabItem value="icp">
 ```bash title="Terminal"
-$ meroctl context create --application-id <app-id> --protocol icp
->> <context-id>
+meroctl context create --application-id <app-id> --protocol icp
 ```
 </TabItem>
 

--- a/versioned_docs/version-0.3.0/06-tutorials/06-install-application.mdx
+++ b/versioned_docs/version-0.3.0/06-tutorials/06-install-application.mdx
@@ -14,8 +14,9 @@ you need to create new context where application will be installed.
 
 To create new context, node CLI has to be used.
 
-If the node doesn't have application installed, you need to install the application first.
-If the application is already installed, you can skip this step.
+If the node doesn't have application installed, you need to install the
+application first. If the application is already installed, you can skip this
+step.
 
 ```bash
 meroctl app install --path /path/to/app

--- a/versioned_docs/version-0.3.0/06-tutorials/06-install-application.mdx
+++ b/versioned_docs/version-0.3.0/06-tutorials/06-install-application.mdx
@@ -3,32 +3,57 @@ id: install-application
 title: Install application
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 We have created simple and easy to use example application called `only-peers`.
 Application enables writing posts and leaving comments. To try out application
 you need to create new context where application will be installed.
 
 ### Create new context
 
-To create new context, node CLI has to be used. There are two possible options
-of creating new context.
+To create new context, node CLI has to be used.
 
-1. If the node already has application installed, create new context using
-   command:
+If the node doesn't have application installed, you need to install the application first.
+If the application is already installed, you can skip this step.
 
-```bash title="Terminal"
-$ meroctl context create --application <app-id>
->> <context-id>
-```
-
-2. If application is not installed then install the application and create new
-   context using commands:
-
-```bash title="Terminal"
+```bash
 $ meroctl app install --path /path/to/app
 >> <app-id>
-$ meroctl context create --application <app-id>
+```
+
+After the application is installed, you can create new context:
+
+<Tabs
+    defaultValue="near"
+    values={[
+        {label: 'Near', value: 'near'},
+        {label: 'Starknet', value: 'starknet'},
+        {label: 'ICP', value: 'icp'},
+    ]}>
+
+<TabItem value="near">
+```bash title="Terminal"
+$ meroctl context create --application-id <app-id> --protocol near
 >> <context-id>
 ```
+</TabItem>
+
+<TabItem value="starknet">
+```bash title="Terminal"
+$ meroctl context create --application-id <app-id> --protocol starknet
+>> <context-id>
+```
+</TabItem>
+
+<TabItem value="icp">
+```bash title="Terminal"
+$ meroctl context create --application-id <app-id> --protocol icp
+>> <context-id>
+```
+</TabItem>
+
+</Tabs>
 
 You are now part of the context and can start using the application.
 


### PR DESCRIPTION
In Tutorial -> Install Application

- Fixed steps
- Fixed wrong application flag (from `--application` to `--application-id`)
- Added `--protocol` flag


Made above changes to both stable and Next versions of documentation
