### PR TITLE
docs: add capability management API endpoints to documentation

### DIFF
--- a/docs/05-developer-tools/02-SDK/04-client-sdk/calimero-client-js.mdx
+++ b/docs/05-developer-tools/02-SDK/04-client-sdk/calimero-client-js.mdx
@@ -255,6 +255,10 @@ try {
 - `GET /admin-api/contexts/:context_id/identities` - Get context identities
 - `POST /admin-api/contexts/invite` - Invite to context
 - `POST /admin-api/contexts/join` - Join context
+- `POST /admin-api/contexts/:context_id/capabilities/grant` - Grant capabilities
+  to context identities
+- `POST /admin-api/contexts/:context_id/capabilities/revoke` - Revoke
+  capabilities from context identities
 
 #### Identity Management
 
@@ -300,6 +304,26 @@ try {
 ```
 
 - Creates an alias for an application ID.
+
+##### Capabilities Management
+
+```http title="POST /admin-api/contexts/:context_id/capabilities/grant"
+{
+  "capabilities": [["ContextIdentity", "Capability"]],
+  "signer_id": "PublicKey"
+}
+```
+
+- Grants specific capabilities to context identities.
+
+```http title="POST /admin-api/contexts/:context_id/capabilities/revoke"
+{
+  "capabilities": [["ContextIdentity", "Capability"]],
+  "signer_id": "PublicKey"
+}
+```
+
+- Revokes specific capabilities from context identities.
 
 ##### Lookup routes
 

--- a/versioned_docs/version-0.5.0/05-developer-tools/02-SDK/04-client-sdk/calimero-client-js.mdx
+++ b/versioned_docs/version-0.5.0/05-developer-tools/02-SDK/04-client-sdk/calimero-client-js.mdx
@@ -255,6 +255,10 @@ try {
 - `GET /admin-api/contexts/:context_id/identities` - Get context identities
 - `POST /admin-api/contexts/invite` - Invite to context
 - `POST /admin-api/contexts/join` - Join context
+- `POST /admin-api/contexts/:context_id/capabilities/grant` - Grant capabilities
+  to context identities
+- `POST /admin-api/contexts/:context_id/capabilities/revoke` - Revoke
+  capabilities from context identities
 
 #### Identity Management
 
@@ -300,6 +304,26 @@ try {
 ```
 
 - Creates an alias for an application ID.
+
+##### Capabilities Management
+
+```http title="POST /admin-api/contexts/:context_id/capabilities/grant"
+{
+  "capabilities": [["ContextIdentity", "Capability"]],
+  "signer_id": "PublicKey"
+}
+```
+
+- Grants specific capabilities to context identities.
+
+```http title="POST /admin-api/contexts/:context_id/capabilities/revoke"
+{
+  "capabilities": [["ContextIdentity", "Capability"]],
+  "signer_id": "PublicKey"
+}
+```
+
+- Revokes specific capabilities from context identities.
 
 ##### Lookup routes
 


### PR DESCRIPTION
   This PR adds documentation for the new capability management API endpoints introduced in calimero-network/core#1233.
   
   The changes include:
   - Adding new endpoints for granting and revoking capabilities in the API endpoints list
   - Adding details about the request format for these capability management endpoints
   
   Closes calimero-network/core#1233