### PR TITLE
fix: update meroctl node name argument

### DIFF
--- a/docs/05-developer-tools/01-CLI/02-meroctl.mdx
+++ b/docs/05-developer-tools/01-CLI/02-meroctl.mdx
@@ -18,7 +18,7 @@ node directly from the shell.
 ## Usage
 
 ```bash title="Terminal"
-meroctl [OPTIONS] --node-name <NAME> <COMMAND>
+meroctl [OPTIONS] --node <NAME> <COMMAND>
 ```
 
 ### Commands:
@@ -67,18 +67,18 @@ your nodes private key.
 
 ### Examples:
 
-| **Command**                                                                       | **Description**                     |
-| --------------------------------------------------------------------------------- | ----------------------------------- |
-| `meroctl --node-name <NAME> app <COMMAND>`                                        | Command for managing applications   |
-| `meroctl --node-name <NAME> context <COMMAND>`                                    | Command for managing contexts       |
-| `meroctl --node-name <NAME> identity <COMMAND>`                                   | Command for creating identities     |
-| `meroctl --node-name <NAME> proxy <COMMAND>`                                      | Command for managing proxy contract |
-| `meroctl --node-name <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>` | Executing read and write RPC calls  |
+| **Command**                                                                  | **Description**                     |
+| ---------------------------------------------------------------------------- | ----------------------------------- |
+| `meroctl --node <NAME> app <COMMAND>`                                        | Command for managing applications   |
+| `meroctl --node <NAME> context <COMMAND>`                                    | Command for managing contexts       |
+| `meroctl --node <NAME> identity <COMMAND>`                                   | Command for creating identities     |
+| `meroctl --node <NAME> proxy <COMMAND>`                                      | Command for managing proxy contract |
+| `meroctl --node <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>` | Executing read and write RPC calls  |
 
 ### Manage Applications
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> app <COMMAND>
+meroctl --node <NAME> app <COMMAND>
 ```
 
 Commands:
@@ -90,7 +90,7 @@ Commands:
 ### Manage Contexts
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> context <COMMAND>
+meroctl --node <NAME> context <COMMAND>
 ```
 
 Commands:
@@ -119,7 +119,7 @@ The `context identity` command supports alias management to simplify working
 with public keys across contexts:
 
 ```bash
-meroctl --node-name <NAME> context identity <COMMAND>
+meroctl --node <NAME> context identity <COMMAND>
 ```
 
 Commands:
@@ -129,7 +129,7 @@ Commands:
   - Use `--owned` to get only owned identities
 
     ```bash
-    meroctl --node-name <NAME> context identity list <contextId or alias> --owned
+    meroctl --node <NAME> context identity list <contextId or alias> --owned
     ```
 
 - `alias` Manage identity aliases
@@ -145,13 +145,13 @@ The `context` command includes alias management as a subcommand to simplify
 working with context IDs:
 
 ```bash
-meroctl --node-name <NAME> context <COMMAND>
+meroctl --node <NAME> context <COMMAND>
 ```
 
 The alias subcommand structure:
 
 ```bash
-meroctl --node-name <NAME> context alias <COMMAND>
+meroctl --node <NAME> context alias <COMMAND>
 ```
 
 - `add <name> <context-id>` Create new alias for a context
@@ -176,7 +176,7 @@ streamline context management.
 ### Manage Identities
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> identity <COMMAND>
+meroctl --node <NAME> identity <COMMAND>
 ```
 
 Commands:
@@ -186,7 +186,7 @@ Commands:
 ### Command for managing proxy contract
 
 ```bash title="Terminal"
- meroctl --node-name <NAME> proxy <COMMAND>
+ meroctl --node <NAME> proxy <COMMAND>
 ```
 
 Commands:
@@ -196,13 +196,13 @@ Commands:
 ### Show a number of connected peers
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> peers
+meroctl --node <NAME> peers
 ```
 
 ### Executing read and write RPC calls
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>
+meroctl --node <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>
 ```
 
 Arguments:
@@ -219,7 +219,7 @@ Options:
 ### Setup two nodes inside the same context
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> bootstrap <COMMAND> --merod-path <MEROD_PATH> --protocol <PROTOCOL> --app-path [APP_PATH]
+meroctl --node <NAME> bootstrap <COMMAND> --merod-path <MEROD_PATH> --protocol <PROTOCOL> --app-path [APP_PATH]
 ```
 
 Command initializes and run `node1` and `node2` in the same context.

--- a/docs/06-tutorials/06-install-application.mdx
+++ b/docs/06-tutorials/06-install-application.mdx
@@ -19,13 +19,13 @@ application first. If the application is already installed, you can skip this
 step.
 
 ```bash
-meroctl --node-name node1 app install --path /path/to/app
+meroctl --node node1 app install --path /path/to/app
 ```
 
 :::note
 
 If you want to install an application that is published in the registry, check
-`meroctl --node-name node1 app install -h` for options
+`meroctl --node node1 app install -h` for options
 
 :::
 
@@ -43,31 +43,31 @@ After the application is installed, you can create new context:
 
 <TabItem value="near">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol near
+meroctl --node node1 context create --application-id <app-id> --protocol near
 ```
 </TabItem>
 
 <TabItem value="starknet">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol starknet
+meroctl --node node1 context create --application-id <app-id> --protocol starknet
 ```
 </TabItem>
 
 <TabItem value="icp">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol icp
+meroctl --node node1 context create --application-id <app-id> --protocol icp
 ```
 </TabItem>
 
 <TabItem value="stellar">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol stellar
+meroctl --node node1 context create --application-id <app-id> --protocol stellar
 ```
 </TabItem>
 
 <TabItem value="ethereum">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol ethereum
+meroctl --node node1 context create --application-id <app-id> --protocol ethereum
 ```
 </TabItem>
 

--- a/docs/shared/context-create-binary.mdx
+++ b/docs/shared/context-create-binary.mdx
@@ -13,28 +13,28 @@ import TabItem from '@theme/TabItem';
 <TabItem value="near">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol near
+meroctl --node node1 context create --watch <application_path> --protocol near
 ```
 
 </TabItem>
 <TabItem value="starknet">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol starknet
+meroctl --node node1 context create --watch <application_path> --protocol starknet
 ```
 
 </TabItem>
 <TabItem value="icp">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol icp
+meroctl --node node1 context create --watch <application_path> --protocol icp
 ```
 
 </TabItem>
 <TabItem value="stellar">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol stellar
+meroctl --node node1 context create --watch <application_path> --protocol stellar
 ```
 
 </TabItem>
@@ -42,7 +42,7 @@ meroctl --node-name node1 context create --watch <application_path> --protocol s
 <TabItem value="ethereum">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol ethereum
+meroctl --node node1 context create --watch <application_path> --protocol ethereum
 ```
 
 </TabItem>

--- a/versioned_docs/version-0.2.0/03-getting-started/04-example-app.mdx
+++ b/versioned_docs/version-0.2.0/03-getting-started/04-example-app.mdx
@@ -16,7 +16,7 @@ of creating new context.
    command:
 
 ```bash title="Terminal"
-$ meroctl --node-name node1 context create --application <app-id>
+$ meroctl --node node1 context create --application <app-id>
 >> <context-id>
 ```
 
@@ -24,9 +24,9 @@ $ meroctl --node-name node1 context create --application <app-id>
    context using commands:
 
 ```bash title="Terminal"
-$ meroctl --node-name node1 app install --path /path/to/app
+$ meroctl --node node1 app install --path /path/to/app
 >> <app-id>
-$ meroctl --node-name node1 context create --application <app-id>
+$ meroctl --node node1 context create --application <app-id>
 >> <context-id>
 ```
 

--- a/versioned_docs/version-0.3.0/05-developer-tools/01-CLI/02-meroctl.mdx
+++ b/versioned_docs/version-0.3.0/05-developer-tools/01-CLI/02-meroctl.mdx
@@ -18,7 +18,7 @@ node directly from the shell.
 ## Usage
 
 ```bash title="Terminal"
-meroctl [OPTIONS] --node-name <NAME> <COMMAND>
+meroctl [OPTIONS] --node <NAME> <COMMAND>
 ```
 
 ### Commands:
@@ -67,18 +67,18 @@ your nodes private key.
 
 ### Examples:
 
-| **Command**                                                                       | **Description**                     |
-| --------------------------------------------------------------------------------- | ----------------------------------- |
-| `meroctl --node-name <NAME> app <COMMAND>`                                        | Command for managing applications   |
-| `meroctl --node-name <NAME> context <COMMAND>`                                    | Command for managing contexts       |
-| `meroctl --node-name <NAME> identity <COMMAND>`                                   | Command for managing identities     |
-| `meroctl --node-name <NAME> proxy <COMMAND>`                                      | Command for managing proxy contract |
-| `meroctl --node-name <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>` | Executing read and write RPC calls  |
+| **Command**                                                                  | **Description**                     |
+| ---------------------------------------------------------------------------- | ----------------------------------- |
+| `meroctl --node <NAME> app <COMMAND>`                                        | Command for managing applications   |
+| `meroctl --node <NAME> context <COMMAND>`                                    | Command for managing contexts       |
+| `meroctl --node <NAME> identity <COMMAND>`                                   | Command for managing identities     |
+| `meroctl --node <NAME> proxy <COMMAND>`                                      | Command for managing proxy contract |
+| `meroctl --node <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>` | Executing read and write RPC calls  |
 
 ### Manage Applications
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> app <COMMAND>
+meroctl --node <NAME> app <COMMAND>
 ```
 
 Commands:
@@ -90,7 +90,7 @@ Commands:
 ### Manage Contexts
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> context <COMMAND>
+meroctl --node <NAME> context <COMMAND>
 ```
 
 Commands:
@@ -111,7 +111,7 @@ Commands:
         only owned identities
 
               ```bash Terminal
-              meroctl --node-name <NAME> context get <contextId> <SUBCOMMAND>
+              meroctl --node <NAME> context get <contextId> <SUBCOMMAND>
               ```
 
       </details>
@@ -124,7 +124,7 @@ Commands:
 ### Manage Identities
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> identity <COMMAND>
+meroctl --node <NAME> identity <COMMAND>
 ```
 
 Commands:
@@ -134,7 +134,7 @@ Commands:
 ### Command for managing proxy contract
 
 ```bash title="Terminal"
- meroctl --node-name <NAME> proxy <COMMAND>
+ meroctl --node <NAME> proxy <COMMAND>
 ```
 
 Commands:
@@ -144,13 +144,13 @@ Commands:
 ### Show a number of connected peers
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> peers
+meroctl --node <NAME> peers
 ```
 
 ### Executing read and write RPC calls
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>
+meroctl --node <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>
 ```
 
 Arguments:
@@ -167,7 +167,7 @@ Options:
 ### Setup two nodes inside the same context
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> bootstrap <COMMAND> --merod-path <MEROD_PATH> --protocol <PROTOCOL> --app-path [APP_PATH]
+meroctl --node <NAME> bootstrap <COMMAND> --merod-path <MEROD_PATH> --protocol <PROTOCOL> --app-path [APP_PATH]
 ```
 
 Command initializes and run `node1` and `node2` in the same context.

--- a/versioned_docs/version-0.3.0/06-tutorials/06-install-application.mdx
+++ b/versioned_docs/version-0.3.0/06-tutorials/06-install-application.mdx
@@ -19,13 +19,13 @@ application first. If the application is already installed, you can skip this
 step.
 
 ```bash
-meroctl --node-name node1 app install --path /path/to/app
+meroctl --node node1 app install --path /path/to/app
 ```
 
 :::note
 
 If you want to install an application that is published in the registry, check
-`meroctl --node-name node1 app install -h` for options
+`meroctl --node node1 app install -h` for options
 
 :::
 
@@ -41,19 +41,19 @@ After the application is installed, you can create new context:
 
 <TabItem value="near">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol near
+meroctl --node node1 context create --application-id <app-id> --protocol near
 ```
 </TabItem>
 
 <TabItem value="starknet">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol starknet
+meroctl --node node1 context create --application-id <app-id> --protocol starknet
 ```
 </TabItem>
 
 <TabItem value="icp">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol icp
+meroctl --node node1 context create --application-id <app-id> --protocol icp
 ```
 </TabItem>
 

--- a/versioned_docs/version-0.3.0/shared/context-create-binary.mdx
+++ b/versioned_docs/version-0.3.0/shared/context-create-binary.mdx
@@ -11,19 +11,19 @@ import TabItem from '@theme/TabItem';
 
 <TabItem value="near">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol near
+meroctl --node node1 context create --watch <application_path> --protocol near
 ```
 </TabItem>
 
 <TabItem value="starknet">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol starknet
+meroctl --node node1 context create --watch <application_path> --protocol starknet
 ```
 </TabItem>
 
 <TabItem value="icp">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol icp
+meroctl --node node1 context create --watch <application_path> --protocol icp
 ```
 </TabItem>
 

--- a/versioned_docs/version-0.4.0/05-developer-tools/01-CLI/02-meroctl.mdx
+++ b/versioned_docs/version-0.4.0/05-developer-tools/01-CLI/02-meroctl.mdx
@@ -18,7 +18,7 @@ node directly from the shell.
 ## Usage
 
 ```bash title="Terminal"
-meroctl [OPTIONS] --node-name <NAME> <COMMAND>
+meroctl [OPTIONS] --node <NAME> <COMMAND>
 ```
 
 ### Commands:
@@ -67,18 +67,18 @@ your nodes private key.
 
 ### Examples:
 
-| **Command**                                                                       | **Description**                     |
-| --------------------------------------------------------------------------------- | ----------------------------------- |
-| `meroctl --node-name <NAME> app <COMMAND>`                                        | Command for managing applications   |
-| `meroctl --node-name <NAME> context <COMMAND>`                                    | Command for managing contexts       |
-| `meroctl --node-name <NAME> identity <COMMAND>`                                   | Command for creating identities     |
-| `meroctl --node-name <NAME> proxy <COMMAND>`                                      | Command for managing proxy contract |
-| `meroctl --node-name <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>` | Executing read and write RPC calls  |
+| **Command**                                                                  | **Description**                     |
+| ---------------------------------------------------------------------------- | ----------------------------------- |
+| `meroctl --node <NAME> app <COMMAND>`                                        | Command for managing applications   |
+| `meroctl --node <NAME> context <COMMAND>`                                    | Command for managing contexts       |
+| `meroctl --node <NAME> identity <COMMAND>`                                   | Command for creating identities     |
+| `meroctl --node <NAME> proxy <COMMAND>`                                      | Command for managing proxy contract |
+| `meroctl --node <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>` | Executing read and write RPC calls  |
 
 ### Manage Applications
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> app <COMMAND>
+meroctl --node <NAME> app <COMMAND>
 ```
 
 Commands:
@@ -90,7 +90,7 @@ Commands:
 ### Manage Contexts
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> context <COMMAND>
+meroctl --node <NAME> context <COMMAND>
 ```
 
 Commands:
@@ -119,7 +119,7 @@ The `context identity` command supports alias management to simplify working
 with public keys across contexts:
 
 ```bash
-meroctl --node-name <NAME> context identity <COMMAND>
+meroctl --node <NAME> context identity <COMMAND>
 ```
 
 Commands:
@@ -129,7 +129,7 @@ Commands:
   - Use `--owned` to get only owned identities
 
     ```bash
-    meroctl --node-name <NAME> context identity list <contextId or alias> --owned
+    meroctl --node <NAME> context identity list <contextId or alias> --owned
     ```
 
 - `alias` Manage identity aliases
@@ -145,13 +145,13 @@ The `context` command includes alias management as a subcommand to simplify
 working with context IDs:
 
 ```bash
-meroctl --node-name <NAME> context <COMMAND>
+meroctl --node <NAME> context <COMMAND>
 ```
 
 The alias subcommand structure:
 
 ```bash
-meroctl --node-name <NAME> context alias <COMMAND>
+meroctl --node <NAME> context alias <COMMAND>
 ```
 
 - `add <name> <context-id>` Create new alias for a context
@@ -176,7 +176,7 @@ streamline context management.
 ### Manage Identities
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> identity <COMMAND>
+meroctl --node <NAME> identity <COMMAND>
 ```
 
 Commands:
@@ -186,7 +186,7 @@ Commands:
 ### Command for managing proxy contract
 
 ```bash title="Terminal"
- meroctl --node-name <NAME> proxy <COMMAND>
+ meroctl --node <NAME> proxy <COMMAND>
 ```
 
 Commands:
@@ -196,13 +196,13 @@ Commands:
 ### Show a number of connected peers
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> peers
+meroctl --node <NAME> peers
 ```
 
 ### Executing read and write RPC calls
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>
+meroctl --node <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>
 ```
 
 Arguments:
@@ -219,7 +219,7 @@ Options:
 ### Setup two nodes inside the same context
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> bootstrap <COMMAND> --merod-path <MEROD_PATH> --protocol <PROTOCOL> --app-path [APP_PATH]
+meroctl --node <NAME> bootstrap <COMMAND> --merod-path <MEROD_PATH> --protocol <PROTOCOL> --app-path [APP_PATH]
 ```
 
 Command initializes and run `node1` and `node2` in the same context.

--- a/versioned_docs/version-0.4.0/06-tutorials/02-create-context.mdx
+++ b/versioned_docs/version-0.4.0/06-tutorials/02-create-context.mdx
@@ -45,7 +45,7 @@ You have now created a new context.
 To create an alias for this context, use:
 
 ```bash title="Terminal"
-meroctl --node-name node1 context alias add my_context <context_id>
+meroctl --node node1 context alias add my_context <context_id>
 ```
 
 Next step is to invite users to join your context. Continue with

--- a/versioned_docs/version-0.4.0/06-tutorials/06-install-application.mdx
+++ b/versioned_docs/version-0.4.0/06-tutorials/06-install-application.mdx
@@ -19,13 +19,13 @@ application first. If the application is already installed, you can skip this
 step.
 
 ```bash
-meroctl --node-name node1 app install --path /path/to/app
+meroctl --node node1 app install --path /path/to/app
 ```
 
 :::note
 
 If you want to install an application that is published in the registry, check
-`meroctl --node-name node1 app install -h` for options
+`meroctl --node node1 app install -h` for options
 
 :::
 
@@ -42,25 +42,25 @@ After the application is installed, you can create new context:
 
 <TabItem value="near">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol near
+meroctl --node node1 context create --application-id <app-id> --protocol near
 ```
 </TabItem>
 
 <TabItem value="starknet">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol starknet
+meroctl --node node1 context create --application-id <app-id> --protocol starknet
 ```
 </TabItem>
 
 <TabItem value="icp">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol icp
+meroctl --node node1 context create --application-id <app-id> --protocol icp
 ```
 </TabItem>
 
 <TabItem value="stellar">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol stellar
+meroctl --node node1 context create --application-id <app-id> --protocol stellar
 ```
 </TabItem>
 

--- a/versioned_docs/version-0.4.0/shared/context-create-binary.mdx
+++ b/versioned_docs/version-0.4.0/shared/context-create-binary.mdx
@@ -12,28 +12,28 @@ import TabItem from '@theme/TabItem';
 <TabItem value="near">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol near
+meroctl --node node1 context create --watch <application_path> --protocol near
 ```
 
 </TabItem>
 <TabItem value="starknet">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol starknet
+meroctl --node node1 context create --watch <application_path> --protocol starknet
 ```
 
 </TabItem>
 <TabItem value="icp">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol icp
+meroctl --node node1 context create --watch <application_path> --protocol icp
 ```
 
 </TabItem>
 <TabItem value="stellar">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol stellar
+meroctl --node node1 context create --watch <application_path> --protocol stellar
 ```
 
 </TabItem>

--- a/versioned_docs/version-0.5.0/05-developer-tools/01-CLI/02-meroctl.mdx
+++ b/versioned_docs/version-0.5.0/05-developer-tools/01-CLI/02-meroctl.mdx
@@ -18,7 +18,7 @@ node directly from the shell.
 ## Usage
 
 ```bash title="Terminal"
-meroctl [OPTIONS] --node-name <NAME> <COMMAND>
+meroctl [OPTIONS] --node <NAME> <COMMAND>
 ```
 
 ### Commands:
@@ -67,18 +67,18 @@ your nodes private key.
 
 ### Examples:
 
-| **Command**                                                                       | **Description**                     |
-| --------------------------------------------------------------------------------- | ----------------------------------- |
-| `meroctl --node-name <NAME> app <COMMAND>`                                        | Command for managing applications   |
-| `meroctl --node-name <NAME> context <COMMAND>`                                    | Command for managing contexts       |
-| `meroctl --node-name <NAME> identity <COMMAND>`                                   | Command for creating identities     |
-| `meroctl --node-name <NAME> proxy <COMMAND>`                                      | Command for managing proxy contract |
-| `meroctl --node-name <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>` | Executing read and write RPC calls  |
+| **Command**                                                                  | **Description**                     |
+| ---------------------------------------------------------------------------- | ----------------------------------- |
+| `meroctl --node <NAME> app <COMMAND>`                                        | Command for managing applications   |
+| `meroctl --node <NAME> context <COMMAND>`                                    | Command for managing contexts       |
+| `meroctl --node <NAME> identity <COMMAND>`                                   | Command for creating identities     |
+| `meroctl --node <NAME> proxy <COMMAND>`                                      | Command for managing proxy contract |
+| `meroctl --node <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>` | Executing read and write RPC calls  |
 
 ### Manage Applications
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> app <COMMAND>
+meroctl --node <NAME> app <COMMAND>
 ```
 
 Commands:
@@ -90,7 +90,7 @@ Commands:
 ### Manage Contexts
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> context <COMMAND>
+meroctl --node <NAME> context <COMMAND>
 ```
 
 Commands:
@@ -119,7 +119,7 @@ The `context identity` command supports alias management to simplify working
 with public keys across contexts:
 
 ```bash
-meroctl --node-name <NAME> context identity <COMMAND>
+meroctl --node <NAME> context identity <COMMAND>
 ```
 
 Commands:
@@ -129,7 +129,7 @@ Commands:
   - Use `--owned` to get only owned identities
 
     ```bash
-    meroctl --node-name <NAME> context identity list <contextId or alias> --owned
+    meroctl --node <NAME> context identity list <contextId or alias> --owned
     ```
 
 - `alias` Manage identity aliases
@@ -145,13 +145,13 @@ The `context` command includes alias management as a subcommand to simplify
 working with context IDs:
 
 ```bash
-meroctl --node-name <NAME> context <COMMAND>
+meroctl --node <NAME> context <COMMAND>
 ```
 
 The alias subcommand structure:
 
 ```bash
-meroctl --node-name <NAME> context alias <COMMAND>
+meroctl --node <NAME> context alias <COMMAND>
 ```
 
 - `add <name> <context-id>` Create new alias for a context
@@ -176,7 +176,7 @@ streamline context management.
 ### Manage Identities
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> identity <COMMAND>
+meroctl --node <NAME> identity <COMMAND>
 ```
 
 Commands:
@@ -186,7 +186,7 @@ Commands:
 ### Command for managing proxy contract
 
 ```bash title="Terminal"
- meroctl --node-name <NAME> proxy <COMMAND>
+ meroctl --node <NAME> proxy <COMMAND>
 ```
 
 Commands:
@@ -196,13 +196,13 @@ Commands:
 ### Show a number of connected peers
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> peers
+meroctl --node <NAME> peers
 ```
 
 ### Executing read and write RPC calls
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>
+meroctl --node <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>
 ```
 
 Arguments:
@@ -219,7 +219,7 @@ Options:
 ### Setup two nodes inside the same context
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> bootstrap <COMMAND> --merod-path <MEROD_PATH> --protocol <PROTOCOL> --app-path [APP_PATH]
+meroctl --node <NAME> bootstrap <COMMAND> --merod-path <MEROD_PATH> --protocol <PROTOCOL> --app-path [APP_PATH]
 ```
 
 Command initializes and run `node1` and `node2` in the same context.

--- a/versioned_docs/version-0.5.0/06-tutorials/06-install-application.mdx
+++ b/versioned_docs/version-0.5.0/06-tutorials/06-install-application.mdx
@@ -19,13 +19,13 @@ application first. If the application is already installed, you can skip this
 step.
 
 ```bash
-meroctl --node-name node1 app install --path /path/to/app
+meroctl --node node1 app install --path /path/to/app
 ```
 
 :::note
 
 If you want to install an application that is published in the registry, check
-`meroctl --node-name node1 app install -h` for options
+`meroctl --node node1 app install -h` for options
 
 :::
 
@@ -43,31 +43,31 @@ After the application is installed, you can create new context:
 
 <TabItem value="near">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol near
+meroctl --node node1 context create --application-id <app-id> --protocol near
 ```
 </TabItem>
 
 <TabItem value="starknet">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol starknet
+meroctl --node node1 context create --application-id <app-id> --protocol starknet
 ```
 </TabItem>
 
 <TabItem value="icp">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol icp
+meroctl --node node1 context create --application-id <app-id> --protocol icp
 ```
 </TabItem>
 
 <TabItem value="stellar">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol stellar
+meroctl --node node1 context create --application-id <app-id> --protocol stellar
 ```
 </TabItem>
 
 <TabItem value="ethereum">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol ethereum
+meroctl --node node1 context create --application-id <app-id> --protocol ethereum
 ```
 </TabItem>
 

--- a/versioned_docs/version-0.5.0/shared/context-create-binary.mdx
+++ b/versioned_docs/version-0.5.0/shared/context-create-binary.mdx
@@ -13,28 +13,28 @@ import TabItem from '@theme/TabItem';
 <TabItem value="near">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol near
+meroctl --node node1 context create --watch <application_path> --protocol near
 ```
 
 </TabItem>
 <TabItem value="starknet">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol starknet
+meroctl --node node1 context create --watch <application_path> --protocol starknet
 ```
 
 </TabItem>
 <TabItem value="icp">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol icp
+meroctl --node node1 context create --watch <application_path> --protocol icp
 ```
 
 </TabItem>
 <TabItem value="stellar">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol stellar
+meroctl --node node1 context create --watch <application_path> --protocol stellar
 ```
 
 </TabItem>
@@ -42,7 +42,7 @@ meroctl --node-name node1 context create --watch <application_path> --protocol s
 <TabItem value="ethereum">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol ethereum
+meroctl --node node1 context create --watch <application_path> --protocol ethereum
 ```
 
 </TabItem>

--- a/versioned_docs/version-0.6.0/05-developer-tools/01-CLI/02-meroctl.mdx
+++ b/versioned_docs/version-0.6.0/05-developer-tools/01-CLI/02-meroctl.mdx
@@ -18,7 +18,7 @@ node directly from the shell.
 ## Usage
 
 ```bash title="Terminal"
-meroctl [OPTIONS] --node-name <NAME> <COMMAND>
+meroctl [OPTIONS] --node <NAME> <COMMAND>
 ```
 
 ### Commands:
@@ -67,18 +67,18 @@ your nodes private key.
 
 ### Examples:
 
-| **Command**                                                                       | **Description**                     |
-| --------------------------------------------------------------------------------- | ----------------------------------- |
-| `meroctl --node-name <NAME> app <COMMAND>`                                        | Command for managing applications   |
-| `meroctl --node-name <NAME> context <COMMAND>`                                    | Command for managing contexts       |
-| `meroctl --node-name <NAME> identity <COMMAND>`                                   | Command for creating identities     |
-| `meroctl --node-name <NAME> proxy <COMMAND>`                                      | Command for managing proxy contract |
-| `meroctl --node-name <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>` | Executing read and write RPC calls  |
+| **Command**                                                                  | **Description**                     |
+| ---------------------------------------------------------------------------- | ----------------------------------- |
+| `meroctl --node <NAME> app <COMMAND>`                                        | Command for managing applications   |
+| `meroctl --node <NAME> context <COMMAND>`                                    | Command for managing contexts       |
+| `meroctl --node <NAME> identity <COMMAND>`                                   | Command for creating identities     |
+| `meroctl --node <NAME> proxy <COMMAND>`                                      | Command for managing proxy contract |
+| `meroctl --node <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>` | Executing read and write RPC calls  |
 
 ### Manage Applications
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> app <COMMAND>
+meroctl --node <NAME> app <COMMAND>
 ```
 
 Commands:
@@ -90,7 +90,7 @@ Commands:
 ### Manage Contexts
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> context <COMMAND>
+meroctl --node <NAME> context <COMMAND>
 ```
 
 Commands:
@@ -119,7 +119,7 @@ The `context identity` command supports alias management to simplify working
 with public keys across contexts:
 
 ```bash
-meroctl --node-name <NAME> context identity <COMMAND>
+meroctl --node <NAME> context identity <COMMAND>
 ```
 
 Commands:
@@ -129,7 +129,7 @@ Commands:
   - Use `--owned` to get only owned identities
 
     ```bash
-    meroctl --node-name <NAME> context identity list <contextId or alias> --owned
+    meroctl --node <NAME> context identity list <contextId or alias> --owned
     ```
 
 - `alias` Manage identity aliases
@@ -145,13 +145,13 @@ The `context` command includes alias management as a subcommand to simplify
 working with context IDs:
 
 ```bash
-meroctl --node-name <NAME> context <COMMAND>
+meroctl --node <NAME> context <COMMAND>
 ```
 
 The alias subcommand structure:
 
 ```bash
-meroctl --node-name <NAME> context alias <COMMAND>
+meroctl --node <NAME> context alias <COMMAND>
 ```
 
 - `add <name> <context-id>` Create new alias for a context
@@ -176,7 +176,7 @@ streamline context management.
 ### Manage Identities
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> identity <COMMAND>
+meroctl --node <NAME> identity <COMMAND>
 ```
 
 Commands:
@@ -186,7 +186,7 @@ Commands:
 ### Command for managing proxy contract
 
 ```bash title="Terminal"
- meroctl --node-name <NAME> proxy <COMMAND>
+ meroctl --node <NAME> proxy <COMMAND>
 ```
 
 Commands:
@@ -196,13 +196,13 @@ Commands:
 ### Show a number of connected peers
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> peers
+meroctl --node <NAME> peers
 ```
 
 ### Executing read and write RPC calls
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>
+meroctl --node <NAME> call [OPTIONS] --as <EXECUTOR> <CONTEXT_ID> <METHOD>
 ```
 
 Arguments:
@@ -219,7 +219,7 @@ Options:
 ### Setup two nodes inside the same context
 
 ```bash title="Terminal"
-meroctl --node-name <NAME> bootstrap <COMMAND> --merod-path <MEROD_PATH> --protocol <PROTOCOL> --app-path [APP_PATH]
+meroctl --node <NAME> bootstrap <COMMAND> --merod-path <MEROD_PATH> --protocol <PROTOCOL> --app-path [APP_PATH]
 ```
 
 Command initializes and run `node1` and `node2` in the same context.

--- a/versioned_docs/version-0.6.0/06-tutorials/06-install-application.mdx
+++ b/versioned_docs/version-0.6.0/06-tutorials/06-install-application.mdx
@@ -19,13 +19,13 @@ application first. If the application is already installed, you can skip this
 step.
 
 ```bash
-meroctl --node-name node1 app install --path /path/to/app
+meroctl --node node1 app install --path /path/to/app
 ```
 
 :::note
 
 If you want to install an application that is published in the registry, check
-`meroctl --node-name node1 app install -h` for options
+`meroctl --node node1 app install -h` for options
 
 :::
 
@@ -43,31 +43,31 @@ After the application is installed, you can create new context:
 
 <TabItem value="near">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol near
+meroctl --node node1 context create --application-id <app-id> --protocol near
 ```
 </TabItem>
 
 <TabItem value="starknet">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol starknet
+meroctl --node node1 context create --application-id <app-id> --protocol starknet
 ```
 </TabItem>
 
 <TabItem value="icp">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol icp
+meroctl --node node1 context create --application-id <app-id> --protocol icp
 ```
 </TabItem>
 
 <TabItem value="stellar">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol stellar
+meroctl --node node1 context create --application-id <app-id> --protocol stellar
 ```
 </TabItem>
 
 <TabItem value="ethereum">
 ```bash title="Terminal"
-meroctl --node-name node1 context create --application-id <app-id> --protocol ethereum
+meroctl --node node1 context create --application-id <app-id> --protocol ethereum
 ```
 </TabItem>
 

--- a/versioned_docs/version-0.6.0/shared/context-create-binary.mdx
+++ b/versioned_docs/version-0.6.0/shared/context-create-binary.mdx
@@ -13,28 +13,28 @@ import TabItem from '@theme/TabItem';
 <TabItem value="near">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol near
+meroctl --node node1 context create --watch <application_path> --protocol near
 ```
 
 </TabItem>
 <TabItem value="starknet">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol starknet
+meroctl --node node1 context create --watch <application_path> --protocol starknet
 ```
 
 </TabItem>
 <TabItem value="icp">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol icp
+meroctl --node node1 context create --watch <application_path> --protocol icp
 ```
 
 </TabItem>
 <TabItem value="stellar">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol stellar
+meroctl --node node1 context create --watch <application_path> --protocol stellar
 ```
 
 </TabItem>
@@ -42,7 +42,7 @@ meroctl --node-name node1 context create --watch <application_path> --protocol s
 <TabItem value="ethereum">
 
 ```bash title="Terminal"
-meroctl --node-name node1 context create --watch <application_path> --protocol ethereum
+meroctl --node node1 context create --watch <application_path> --protocol ethereum
 ```
 
 </TabItem>


### PR DESCRIPTION
meroctl's `--node-name` argument was changed to `--name` in this [PR](https://github.com/calimero-network/core/pull/1237).

This PR updates the docs to reflect that change