### PR TITLE
Add llms.txt support

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -81,7 +81,47 @@ const config: Config = {
       } as Preset.Options,
     ],
   ],
-  plugins: ['docusaurus-plugin-sass'],
+  plugins: [
+    'docusaurus-plugin-sass',
+    [
+      'docusaurus-plugin-llms',
+      {
+        // Use custom static/llms.txt for summary, let plugin generate full version
+        outputPath: '/llms-auto.txt', // Plugin generates to different path
+        generateFullVersion: true,
+        // Optional: customize the title (defaults to your site title)
+        title: 'Calimero Network',
+        // Optional: customize the description (defaults to your site tagline)
+        description: "Calimero Network is a framework which enables building fully decentralized applications, ensuring everyone's data privacy.",
+        // Optional: customize the sections
+        sections: {
+          // Optional: customize section names and descriptions
+          'Core Concepts': 'Essential concepts and terminology for understanding Calimero Network',
+          'Getting Started': 'Setup guides and quick start tutorials',
+          'Architecture': 'System architecture and technical details',
+          'Developer Tools': 'CLI tools, SDKs, and development utilities',
+          'Tutorials': 'Step-by-step guides and examples',
+          'Resources': 'Additional documentation and references',
+        },
+        // Optional: exclude certain paths from being included
+        exclude: ['**/shared/**', '**/_*.{js,jsx,ts,tsx,md,mdx}'],
+        // Optional: include external links
+        externalLinks: [
+          {
+            title: 'Calimero Network Website',
+            url: 'https://www.calimero.network/',
+            description: 'Official Calimero Network website'
+          },
+          {
+            title: 'GitHub Repository',
+            url: 'https://github.com/calimero-network/core',
+            description: 'Main Calimero Network repository'
+          }
+        ],
+
+      }
+    ]
+  ],
   themeConfig: {
     colorMode: {
       disableSwitch: false,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build && node scripts/replace-llms.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -15,6 +15,7 @@
     "typecheck": "tsc",
     "format:md": "prettier --write \"**/*.{md,mdx}\"",
     "check:md": "prettier --check \"**/*.{md,mdx}\"",
+    "update:llms": "node scripts/replace-llms.js",
     "prepare": "husky"
   },
   "dependencies": {
@@ -26,6 +27,7 @@
     "@feelback/react": "^0.3.4",
     "@mdx-js/react": "^3.1.0",
     "clsx": "^2.1.1",
+    "docusaurus-plugin-llms": "^0.1.5",
     "docusaurus-plugin-sass": "^0.2.6",
     "prism-react-renderer": "^2.4.0",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      docusaurus-plugin-llms:
+        specifier: ^0.1.5
+        version: 0.1.5(@docusaurus/core@3.8.1(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))
       docusaurus-plugin-sass:
         specifier: ^0.2.6
         version: 0.2.6(@docusaurus/core@3.8.1(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(sass@1.81.1)(webpack@5.96.1)
@@ -2084,6 +2087,9 @@ packages:
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -2739,6 +2745,12 @@ packages:
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
+
+  docusaurus-plugin-llms@0.1.5:
+    resolution: {integrity: sha512-TKcHQG6MyTTleDdOFJL+5OpmW9Le6XGiagClgSX05GXhxD//4PQlY2Iq9HVETLBIsHVETVp8AxjZQ6e3E/fr/Q==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
 
   docusaurus-plugin-sass@0.2.6:
     resolution: {integrity: sha512-2hKQQDkrufMong9upKoG/kSHJhuwd+FA3iAe/qzS/BmWpbIpe7XKmq5wlz4J5CJaOPu4x+iDJbgAxZqcoQf0kg==}
@@ -3912,6 +3924,10 @@ packages:
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -8573,6 +8589,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -9260,6 +9280,12 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
+
+  docusaurus-plugin-llms@0.1.5(@docusaurus/core@3.8.1(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)):
+    dependencies:
+      '@docusaurus/core': 3.8.1(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      gray-matter: 4.0.3
+      minimatch: 9.0.5
 
   docusaurus-plugin-sass@0.2.6(@docusaurus/core@3.8.1(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1))(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2))(sass@1.81.1)(webpack@5.96.1):
     dependencies:
@@ -10803,6 +10829,10 @@ snapshots:
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
 

--- a/scripts/replace-llms.js
+++ b/scripts/replace-llms.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// Paths
+const customLlmsPath = path.join(__dirname, '../static/llms.txt');
+const buildLlmsPath = path.join(__dirname, '../build/llms.txt');
+
+console.log('🔄 Replacing plugin-generated llms.txt with custom content...');
+
+try {
+  // Read our custom llms.txt
+  const customContent = fs.readFileSync(customLlmsPath, 'utf8');
+  
+  // Write it to the build directory, replacing the plugin's output
+  fs.writeFileSync(buildLlmsPath, customContent, 'utf8');
+  
+  console.log('✅ Successfully replaced llms.txt with custom content');
+  console.log(`📁 Custom content written to: ${buildLlmsPath}`);
+  
+} catch (error) {
+  console.error('❌ Error replacing llms.txt:', error.message);
+  process.exit(1);
+}

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,96 @@
+# Calimero Network
+
+> Calimero Network is a framework which enables building fully decentralized applications, ensuring everyone's data privacy through peer-to-peer Self-Sovereign applications with verified off-chain computing.
+
+Calimero Network provides a comprehensive development framework for building decentralized applications that prioritize data ownership and privacy. The framework uses WebAssembly (WASM) for secure application execution and provides a robust runtime environment for managing peer-to-peer networks.
+
+## Introduction
+
+- [What is Calimero](https://calimero-network.github.io/docs/01-introduction/01-what-is-calimero): A development framework for building peer-to-peer Self-Sovereign applications focusing on data ownership and verified off-chain computing
+- [Use Cases](https://calimero-network.github.io/docs/01-introduction/02-use-cases): Explore various applications and scenarios where Calimero Network can be effectively utilized
+- [Key Features](https://calimero-network.github.io/docs/01-introduction/03-key-features): Discover the core capabilities including decentralized networks, WASM applications, and privacy-focused architecture
+
+## Getting Started
+
+- [Setup](https://calimero-network.github.io/docs/02-getting-started/01-setup): Complete setup guide for getting Calimero Network running on your system
+- [Packaged Installation](https://calimero-network.github.io/docs/02-getting-started/02-packaged): Quick installation using pre-built packages for easy deployment
+- [Build From Source](https://calimero-network.github.io/docs/02-getting-started/03-build-from-source): Step-by-step guide to building Calimero Network from source code
+
+## Core Concepts
+
+- [Terminology](https://calimero-network.github.io/docs/03-core-concepts/01-terminology): Essential vocabulary and concepts for understanding Calimero Network architecture
+- [Identity](https://calimero-network.github.io/docs/03-core-concepts/03-identity): Decentralized identity framework providing secure authentication and user management
+- [Contexts](https://calimero-network.github.io/docs/03-core-concepts/04-context): Application-specific networks enabling direct communication between users
+- [Applications](https://calimero-network.github.io/docs/03-core-concepts/05-applications): Core logic governing how peers interact within the network
+- [Blockchain Integration](https://calimero-network.github.io/docs/03-core-concepts/06-blockchain-integration): How Calimero integrates with existing blockchain networks
+- [Encryption](https://calimero-network.github.io/docs/03-core-concepts/07-encryption): Security features ensuring data privacy and secure communication
+- [Specialized Nodes](https://calimero-network.github.io/docs/03-core-concepts/08-specialized-nodes): Third-party nodes providing additional services like encrypted storage and delegated execution
+
+## Architecture
+
+- [System Overview](https://calimero-network.github.io/docs/04-architecture/01-system-overview): High-level architecture and system design principles
+- [Client Node](https://calimero-network.github.io/docs/04-architecture/03-node/01-client-node): Runtime environment and capabilities of client nodes
+- [Runtime](https://calimero-network.github.io/docs/04-architecture/03-node/02-runtime): Execution environment managing applications and state synchronization
+- [Server](https://calimero-network.github.io/docs/04-architecture/03-node/03-server): Server components for node interaction and management
+- [Storage](https://calimero-network.github.io/docs/04-architecture/03-node/04-storage): Data management and storage capabilities
+- [Network](https://calimero-network.github.io/docs/04-architecture/03-node/05-network): Networking components and peer-to-peer communication
+
+## Developer Tools
+
+- [Merod](https://calimero-network.github.io/docs/05-developer-tools/01-CLI/01-merod): Command-line tool for managing Calimero nodes
+- [Meroctl](https://calimero-network.github.io/docs/05-developer-tools/01-CLI/02-meroctl): Control utility for node operations and management
+- [Cargo Mero](https://calimero-network.github.io/docs/05-developer-tools/01-CLI/03-cargo-mero): Rust package manager integration for Calimero development
+- [Protocol SDK](https://calimero-network.github.io/docs/05-developer-tools/02-SDK/03-protocol-sdk/01-protocol-sdk): Foundation tools for building application logic in Rust
+- [Client SDK](https://calimero-network.github.io/docs/05-developer-tools/02-SDK/04-client-sdk/calimero-client-js): TypeScript SDK for creating user interfaces and handling authentication
+- [Admin Dashboard](https://calimero-network.github.io/docs/05-developer-tools/03-apps/05-admin-dashboard): Web-based interface for node management and monitoring
+- [Desktop App](https://calimero-network.github.io/docs/05-developer-tools/03-apps/06-desktop-app): Desktop application for managing Calimero nodes
+
+## Tutorials
+
+- [Near Wallet Integration](https://calimero-network.github.io/docs/06-tutorials/01-login-with-wallets/01-near-wallet): Authenticate users via NEAR wallet for secure access
+- [Starknet Wallet Integration](https://calimero-network.github.io/docs/06-tutorials/01-login-with-wallets/02-starknet-wallet): Integrate Starknet wallet authentication
+- [ICP Wallet Integration](https://calimero-network.github.io/docs/06-tutorials/01-login-with-wallets/03-icp-wallet): Internet Identity authentication integration
+- [Create Context](https://calimero-network.github.io/docs/06-tutorials/02-create-context): Step-by-step guide to creating application contexts
+- [Key-Value Store Tutorial](https://calimero-network.github.io/docs/06-tutorials/04-build-app): Build applications using the Calimero SDK for Rust
+- [Publish App](https://calimero-network.github.io/docs/06-tutorials/05-publish-app): Deploy and publish your applications to the network
+- [Install Application](https://calimero-network.github.io/docs/06-tutorials/06-install-application): Install and run applications on your Calimero node
+
+## Example Projects
+
+- [Only Peers](https://calimero-network.github.io/docs/06-tutorials/07-awesome-projects/01-only-peers): Decentralized social networking application
+- [Private DAO](https://calimero-network.github.io/docs/06-tutorials/07-awesome-projects/02-demo-blockchain-integration): Example application connecting to Calimero Proxy Contract
+- [Rock Paper Scissors](https://calimero-network.github.io/docs/06-tutorials/07-awesome-projects/_03-rock-paper-scissors): Online multiplayer game with enforced rules
+- [Blockchain Integration](https://calimero-network.github.io/docs/06-tutorials/07-proxy-contract-interaction): Cross-chain interactions through proxy contracts
+
+## Resources
+
+- [Data Sovereignty Manifesto](https://calimero-network.github.io/docs/07-resources/01-manifesto): Vision for a digital world where users control their data
+- [ELI5](https://calimero-network.github.io/docs/07-resources/02-eli5): Simple explanations of complex concepts
+- [Changelog](https://calimero-network.github.io/docs/07-resources/_02-changelog): Version history and updates
+- [Versioning](https://calimero-network.github.io/docs/07-resources/_03-versioning): Version management and compatibility information
+
+## Troubleshooting
+
+- [General Issues](https://calimero-network.github.io/docs/08-throubleshooting/01-overview): Common problems and solutions
+- [SSL/TLS Configuration](https://calimero-network.github.io/docs/08-throubleshooting/02-ssl): Secure access configuration for external connections
+- [Limitations](https://calimero-network.github.io/docs/08-throubleshooting/_02-limitations): Current framework limitations and constraints
+
+## Contributing
+
+- [GitHub Workflow](https://calimero-network.github.io/docs/09-contributing/01-github): How to contribute to the project
+- [Hackathons](https://calimero-network.github.io/docs/09-contributing/02-hackathons): Innovation and collaboration opportunities
+- [Bounty Program](https://calimero-network.github.io/docs/09-contributing/03-bounty-program): Rewards for contributions and improvements
+
+## Support
+
+- [Community and Support](https://calimero-network.github.io/docs/10-support/01-community-and-support): Get help from the Calimero community
+- [Learning Resources](https://calimero-network.github.io/docs/10-support/02-learning): Additional materials and references
+
+## External Resources
+
+- [Calimero Network Website](https://www.calimero.network/): Official website with additional information and resources
+- [GitHub Repository](https://github.com/calimero-network/core): Main source code repository and development hub
+
+## Optional
+
+- [Full Documentation](https://calimero-network.github.io/docs/llms-full.txt): Complete documentation content for comprehensive reference


### PR DESCRIPTION
## Add LLMS.txt Support for AI-Friendly Documentation

### What This PR Does

This PR implements the [llms.txt standard](https://llmstxt.org/) to make our Calimero Network documentation more accessible to AI assistants and LLMs. We now provide two LLM-friendly documentation files:

- **`/llms.txt`** - Rich, curated summary with proper descriptions
- **`/llms-full.txt`** - Complete documentation content for comprehensive reference

### Why Custom Generated llms.txt

The current `docusaurus-plugin-llms` (v0.1.5) has limitations with MDX content extraction:
- ❌ Truncated descriptions that don't make sense
- ❌ Raw MDX imports leaking through instead of actual content  
- ❌ Poor quality summaries that don't help LLMs understand the content

Our custom `static/llms.txt` provides:
- ✅ Rich, well-written descriptions for each documentation section
- ✅ Proper context about what each page contains
- ✅ Clean, LLM-friendly formatting following the llms.txt specification

### How to Generate/Update llms.txt

**Currently, the custom llms.txt can only be updated manually** since it requires human curation and understanding of the content. The file is located at `static/llms.txt`.

**For major documentation changes:**
1. Edit `static/llms.txt` directly
2. Run `pnpm update:llms` to test locally
3. Commit the changes

**Note:** This approach requires manual maintenance but ensures high-quality, meaningful descriptions that actually help LLMs understand our documentation.

### Technical Implementation

- **Plugin Configuration**: Uses `docusaurus-plugin-llms` for auto-generating `llms-full.txt`
- **Custom Summary**: Maintains `static/llms.txt` for quality control
- **Post-build Script**: `scripts/replace-llms.js` automatically replaces plugin output with custom content
- **Build Integration**: `pnpm build` now includes automatic llms.txt replacement

### Commands Added

```bash
pnpm build          # Build docs + auto-replace llms.txt
pnpm update:llms    # Manually update llms.txt only
```

### Future Improvements

We will:
1. **File an issue** on the `docusaurus-plugin-llms` repository reporting the MDX content extraction problems
2. **Monitor the plugin** for improvements in content processing
3. **Consider migrating** to auto-generated summaries once the plugin can properly handle MDX content

### About llms-full.txt

The `llms-full.txt` file is generated by the plugin during build time and contains the complete documentation content. It's not committed to the repository since it's auto-generated, but it's available at `/llms-full.txt` on the built site for comprehensive LLM reference.