### PR TITLE
Update docusaurus_deploy.yml

### DIFF
--- a/.github/workflows/docusaurus_deploy.yml
+++ b/.github/workflows/docusaurus_deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm


### PR DESCRIPTION
for some reason GH action wants to use node 18 and it breaks the build, this should fix it